### PR TITLE
Implement Documentation Page

### DIFF
--- a/src/api/documentation/content-types/documentation/schema.json
+++ b/src/api/documentation/content-types/documentation/schema.json
@@ -1,0 +1,25 @@
+{
+  "kind": "collectionType",
+  "collectionName": "documentations",
+  "info": {
+    "singularName": "documentation",
+    "pluralName": "documentations",
+    "displayName": "Documentation",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "section_title": {
+      "type": "string"
+    },
+    "subsections": {
+      "displayName": "Subsections",
+      "type": "component",
+      "repeatable": true,
+      "component": "subsections.subsections"
+    }
+  }
+}

--- a/src/api/documentation/controllers/documentation.js
+++ b/src/api/documentation/controllers/documentation.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * documentation controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::documentation.documentation');

--- a/src/api/documentation/routes/documentation.js
+++ b/src/api/documentation/routes/documentation.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * documentation router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::documentation.documentation');

--- a/src/api/documentation/services/documentation.js
+++ b/src/api/documentation/services/documentation.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * documentation service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::documentation.documentation');

--- a/src/components/subsections/subsections.json
+++ b/src/components/subsections/subsections.json
@@ -1,0 +1,19 @@
+{
+  "collectionName": "components_subsections_subsections",
+  "info": {
+    "displayName": "Subsections",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "content": {
+      "type": "richtext"
+    },
+    "href": {
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
Goal: Add documentation features and functionality to the SAF site.

- [X]  Add documentation collection type
- [X]  Add subsection component for ease of replication

Note:  Roles for documentation will need to be changed in strapi admin panel to have proper authentication for graphql queries