### PR TITLE
Homepage Schema Update

### DIFF
--- a/src/api/capability/content-types/capability/schema.json
+++ b/src/api/capability/content-types/capability/schema.json
@@ -27,7 +27,7 @@
     },
     "icon": {
       "type": "media",
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "allowedTypes": [
         "images"


### PR DESCRIPTION
Limit capabilities icons to one single media option.  This will limit icons to one icon per entry as it should be, resolving issue in frontend. 