### PR TITLE
Upgrade to New Heroku Plan

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
   ],
   "repository": "https://github.com/strapi/strapi-heroku-template",
   "addons": [
-    "heroku-postgresql:hobby-dev"
+    "heroku-postgresql:essential-0"
   ],
   "image": "heroku/nodejs",
   "buildpacks": [

--- a/package.json
+++ b/package.json
@@ -42,5 +42,5 @@
     ],
     "testEnvironment": "node"
   },
-  "packageManager": "yarn@3.5.1"
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
As announced on May 1, 2024, Heroku Postgres mini and basic plans will reach end-of-life (EOL) on May 22, 2024.
Heimdall was using heroku-postgresql:mini.

Make the necessary changes in the app.json, update to the new Essential plan to:
heroku-postgresql:mini → heroku-postgresql:essential-0